### PR TITLE
User/milos/bug/chat fixes

### DIFF
--- a/src/Scripts/UI/Controls/MessageMarkdown.gd
+++ b/src/Scripts/UI/Controls/MessageMarkdown.gd
@@ -51,7 +51,8 @@ func _render_history_item():
 	# create_code_labels()
 
 func _toggle_controls(enabled:= true):
-	get_tree().call_group("controls", "set_disabled", not enabled)
+	if is_inside_tree():
+		get_tree().call_group("controls", "set_disabled", not enabled)
 
 func _setup_user_message():
 	right_control.visible = true

--- a/src/Scripts/UI/Views/ChatPane.gd
+++ b/src/Scripts/UI/Views/ChatPane.gd
@@ -34,6 +34,8 @@ func create_prompt(append_item: ChatHistoryItem = null) -> Array[Variant]:
 	
 	var working_memory: String = SingletonObject.NotesTab.To_Prompt(provider)
 
+	print(working_memory)
+
 	# history will turn it into a prompts using the selected provider
 	var history_list: Array[Variant] = history.To_Prompt()
 
@@ -80,7 +82,6 @@ func _on_chat_pressed():
 	
 	# Ensure we have open chat so we can get its history and disable the notes
 	ensure_chat_open()
-	SingletonObject.NotesTab.Disable_All()
 
 	var history: ChatHistory = SingletonObject.ChatList[current_tab]
 
@@ -121,6 +122,9 @@ func _on_chat_pressed():
 
 		user_msg_node = lst_chi.rendered_node
 		user_history_item = lst_chi
+	
+	# we made the prompt, disable the notes now
+	SingletonObject.NotesTab.Disable_All()
 
 	# Add empty history item, to show the loading state
 	var dummy_item = ChatHistoryItem.new()


### PR DESCRIPTION
Fixed message outside of the tree when closing the chat tab.
Fixed notes not injected into the prompt