### PR TITLE
User/milos/feature/image edit workflow

### DIFF
--- a/src/Scenes/ChatImage.tscn
+++ b/src/Scenes/ChatImage.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=7 format=3 uid="uid://r5b4cwe432qh"]
+[gd_scene load_steps=8 format=3 uid="uid://r5b4cwe432qh"]
 
 [ext_resource type="Script" path="res://Scripts/UI/Controls/ChatImage.gd" id="1_6oqm2"]
 [ext_resource type="Texture2D" uid="uid://cx862fulcqndu" path="res://assets/icons/edit_icons/edit.svg" id="2_0hlvg"]
+[ext_resource type="Texture2D" uid="uid://c3dh20fijyn88" path="res://assets/icons/grid_minimap.svg" id="2_3432p"]
 [ext_resource type="Texture2D" uid="uid://dnnxmw21cvna4" path="res://assets/generated/pencil_icon_24_no_bg.png" id="3_ix1p3"]
 [ext_resource type="Texture2D" uid="uid://puwjyorobokk" path="res://assets/icons/download_icons/download_white.png" id="4_8rp1f"]
 
@@ -42,13 +43,17 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_2gddn")
 [node name="h" type="HBoxContainer" parent="v/p"]
 layout_mode = 2
 
+[node name="MaskButton" type="Button" parent="v/p/h"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+tooltip_text = "Edit Mask Applied"
+icon = ExtResource("2_3432p")
+flat = true
+
 [node name="Label" type="Label" parent="v/p/h"]
 layout_mode = 2
 text = "Image"
-
-[node name="CheckButton" type="CheckButton" parent="v/p/h"]
-unique_name_in_owner = true
-layout_mode = 2
 
 [node name="HBoxContainer" type="HBoxContainer" parent="v/p/h"]
 layout_mode = 2
@@ -77,7 +82,6 @@ size_flags_vertical = 3
 expand_mode = 5
 
 [connection signal="file_selected" from="SaveFileDialog" to="." method="_on_save_file_dialog_file_selected"]
-[connection signal="toggled" from="v/p/h/CheckButton" to="." method="_on_check_button_toggled"]
 [connection signal="pressed" from="v/p/h/HBoxContainer/EditButton" to="." method="_on_edit_button_pressed"]
 [connection signal="pressed" from="v/p/h/HBoxContainer/NoteButton" to="." method="_on_note_button_pressed"]
 [connection signal="pressed" from="v/p/h/HBoxContainer/SaveButton" to="." method="_on_save_button_pressed"]

--- a/src/Scenes/GraphicsEditor.tscn
+++ b/src/Scenes/GraphicsEditor.tscn
@@ -77,10 +77,9 @@ unique_name_in_owner = true
 editor_description = "Layers"
 visible = false
 layout_mode = 2
-item_count = 1
 selected = 0
+item_count = 1
 popup/item_0/text = "Layer1"
-popup/item_0/id = 0
 
 [node name="addlayer" type="Button" parent="VBoxContainer/MarginContainer/HBoxContainer"]
 unique_name_in_owner = true

--- a/src/Scripts/Services/Providers/OpenAI/DallE.gd
+++ b/src/Scripts/Services/Providers/OpenAI/DallE.gd
@@ -50,12 +50,21 @@ func generate_content(prompt: Array[Variant], additional_params: Dictionary={}) 
 		for mem_item: MemoryItem in thread.MemoryItemList:
 			if mem_item.Enabled and mem_item.MemoryImage:
 				active_image = mem_item.MemoryImage
+	
+	for item: MemoryItem in SingletonObject.DetachedNotes:
+		if item.Type == SingletonObject.note_type.IMAGE and item.Enabled:
+			active_image = item.MemoryImage
+			edit = active_image.has_meta("mask") # if it has a mask it's a edit, otherwise a variation
+			item.Enabled = false
+			break
 
-	for formatted_data in prompt:
-		for image in formatted_data["images"]:
-			if image.get_meta("active", false):
-				active_image = image
-				edit = active_image.has_meta("mask")
+	# Images can't be enabled in the chat anymore, but in the editor or as notes
+	# Editor images have priority
+	# for formatted_data in prompt:
+	# 	for image in formatted_data["images"]:
+	# 		if image.get_meta("active", false):
+	# 			active_image = image
+	# 			edit = active_image.has_meta("mask")
 
 	# Just take the last prompt
 	var request_body = {
@@ -98,10 +107,6 @@ func generate_content(prompt: Array[Variant], additional_params: Dictionary={}) 
 					"Authorization: Bearer %s" % API_KEY
 				],
 			)
-
-		# ChangImage sets the `rendered_node` for the image
-		if active_image.has_meta("rendered_node"):
-			active_image.get_meta("rendered_node").active = false
 
 	else:
 		request_body["model"] = "dall-e-3" # we can use dall-e-3 for generating images

--- a/src/Scripts/UI/Controls/ChatImage.gd
+++ b/src/Scripts/UI/Controls/ChatImage.gd
@@ -74,7 +74,7 @@ func _on_edit_button_pressed():
 	if caption_title.length() > 15:
 		caption_title = caption_title.substr(0, 15) + "..."
 	SingletonObject.is_masking = true
-	var editor: = SingletonObject.editor_container.editor_pane.add(Editor.Type.GRAPHICS, null, caption_title)
+	var editor: = SingletonObject.editor_container.editor_pane.add(Editor.Type.GRAPHICS, null, caption_title, self)
 	editor.graphics_editor.setup_from_image(image)
 	
 

--- a/src/Scripts/UI/Controls/ChatImage.gd
+++ b/src/Scripts/UI/Controls/ChatImage.gd
@@ -7,6 +7,7 @@ signal image_active_state_changed(active: bool)
 
 const _scene: PackedScene = preload("res://Scenes/ChatImage.tscn")
 @onready var _save_dialog = %SaveFileDialog as FileDialog
+@onready var _mask_button = %MaskButton as Button
 
 @export var image: Image:
 	set(value):
@@ -26,6 +27,15 @@ const _scene: PackedScene = preload("res://Scenes/ChatImage.tscn")
 
 		image.set_meta("rendered_node", self)
 
+		# define the signal that's emitted when mask is changed
+		if not image.has_user_signal("mask_changed"):
+			image.add_user_signal("mask_changed")
+			image.connect(
+				"mask_changed",
+				func():
+					_mask_button.visible = image.has_meta("mask")
+			)
+
 func _resize_image_to_fit(max_width: int, max_height: int):
 	# Get the original size of the image
 	var original_size = Vector2(image.get_width(), image.get_height())
@@ -39,14 +49,6 @@ func _resize_image_to_fit(max_width: int, max_height: int):
 		image.resize(new_size.x, new_size.y)
 		# Update the texture
 		%TextureRect.texture = ImageTexture.create_from_image(image)
-
-## Proxy for this nodes `CheckButton.button_pressed` property.
-## Setting this property will result in use of `BaseButton.set_pressed_no_signal`.
-var active: = false:
-	set(value):
-		active = value
-		(%CheckButton as CheckButton).set_pressed_no_signal(value)
-	get: return %CheckButton.button_pressed
 
 
 static func create(image_: Image) -> ChatImage:
@@ -76,9 +78,6 @@ func _on_edit_button_pressed():
 	editor.graphics_editor.setup_from_image(image)
 	
 
-func _on_check_button_toggled(toggled_on: bool):
-	image.set_meta("active", toggled_on)
-	image_active_state_changed.emit(toggled_on)
 
 
 func _on_note_button_pressed():

--- a/src/Scripts/UI/Controls/Editor.gd
+++ b/src/Scripts/UI/Controls/Editor.gd
@@ -24,6 +24,12 @@ enum Type {
 	NOTE_EDITOR,
 }
 
+## May contain the object that is being edited by this editor.[br]
+## Eg. ChatImage, Note, etc..[br]
+## Allows switching to existing editor intead of
+## opening a new one for same associated object.
+var associated_object
+
 ## Callable that overrides what happens when user clicks the editor "save" button.
 var _save_override: Callable
 
@@ -38,9 +44,11 @@ var prompt_save:= true
  # checks if the editor has been saved at least once
 var file_saved_in_disc := false # this is used when you press the save button on the file menu
 
-static func create(type_: Type, file_ = null, name_ = null) -> Editor:
+static func create(type_: Type, file_ = null, name_ = null, associated_object_ = null) -> Editor:
 	var editor = scene.instantiate()
 	editor.type = type_
+	editor.associated_object = associated_object_
+	
 	if name_:
 		editor.tab_title = name_
 	if file_: 

--- a/src/Scripts/UI/Controls/GraphicsEditor.gd
+++ b/src/Scripts/UI/Controls/GraphicsEditor.gd
@@ -255,6 +255,11 @@ func _on_mask_check_button_toggled(toggled_on: bool):
 
 func _on_apply_mask_button_pressed():
 	image.set_meta("mask", _mask_layer.image)
+
+	# if the image has the signal defined call it
+	if image.has_user_signal("mask_changed"):
+		image.emit_signal("mask_changed")
+	
 	_masking = false
 
 func _on_erasing_pressed():

--- a/src/Scripts/UI/Views/EditorPane.gd
+++ b/src/Scripts/UI/Views/EditorPane.gd
@@ -109,19 +109,19 @@ func add_control(item: Node, name_: String) -> Node:
 
 
 
-func add(type: Editor.Type, file = null, name_ = null) -> Editor:
+func add(type: Editor.Type, file = null, name_ = null, associated_object = null) -> Editor:
 	#Add a scroll container to the tabs and put the item in there.
 
-	# check if we're opining a file that's already open
-	# if so jsut switch to that editor
+	# check if we're opening a file that's already open or for the same associated_object (except null)
+	# if so just switch to that editor
 	for editor: Editor in self.Tabs.get_children():
 		if not editor is Editor: 
 			continue
-		if editor.file == file:
+		if editor.file == file or (associated_object != null and editor.associated_object == associated_object):
 			Tabs.current_tab = Tabs.get_tab_idx_from_control(editor)
-			return
+			return editor
 	
-	var editor_node = Editor.create(type, file)
+	var editor_node = Editor.create(type, file, name_, associated_object)
 	
 	editor_node.content_changed.connect(_on_editor_content_changed.bind(editor_node))
 	


### PR DESCRIPTION
Creating a image edit from chat image has been reworked.
- Instead of editing the image in the editor and then enabling the image in chat pane, the images can now be edited (mask applied), which will show a small indicator on the chat image, and then enabled in the editor itself.
- If editor with a image is enabled image edit/variation will be created depending on whether image has a mask applied or not.
- Opening chat image in editor multiple times won't open multiple editors anymore, but instead switch to already open editor.