### PR TITLE
fixed replace all not working when active editor tab is a graphics tab

### DIFF
--- a/src/Scenes/Editor.tscn
+++ b/src/Scenes/Editor.tscn
@@ -185,6 +185,7 @@ layout_mode = 2
 
 [connection signal="gui_input" from="." to="." method="_on_gui_input"]
 [connection signal="gui_input" from="VBoxContainer/CodeEdit" to="." method="_on_code_edit_gui_input"]
+[connection signal="text_changed" from="VBoxContainer/CodeEdit" to="VBoxContainer/CodeEdit" method="_on_text_changed"]
 [connection signal="toggled" from="VBoxContainer/HBoxContainer/CheckButton" to="." method="_on_check_button_toggled"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/reloadButton" to="." method="_on_reload_button_pressed"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/SaveOpenEditorTabsButton" to="." method="_on_save_open_editor_tabs_button_pressed"]

--- a/src/Scripts/UI/Controls/CodeMarkdownLabel.gd
+++ b/src/Scripts/UI/Controls/CodeMarkdownLabel.gd
@@ -44,36 +44,40 @@ func _on_replace_all_pressed():
 	# Get the reference to the EditorPane
 	var ep: EditorPane =  SingletonObject.editor_pane
 	var text_without_tags: String = _parse_code_block(%CodeLabel.text)
-
 	print("Replacing all text in the text editor.")
 	
-	if ep.Tabs.get_tab_count() < 1:
-		ep.add(Editor.Type.TEXT, null ,%SyntaxLabel.text)
-	
 	# Get the currently active tab
-	var current_tab: = ep.Tabs.get_current_tab()
+	var active_tab_editor_node: Editor = ep.Tabs.get_current_tab_control()
 	
+	if ep.Tabs.get_tab_count() < 1:
+		active_tab_editor_node = ep.add(Editor.Type.TEXT, null ,%SyntaxLabel.text, null)
+		print("no active tab")
+	elif active_tab_editor_node.type == Editor.Type.GRAPHICS:
+		active_tab_editor_node = ep.add(Editor.Type.TEXT, null ,%SyntaxLabel.text, null)
+		print("active tab not text")
 	
 	# Check if the active tab is an Editor and is a Text editor
-	if ep.Tabs.get_tab_control(current_tab) is Editor:
-		var editor = ep.Tabs.get_tab_control(current_tab)
-		if editor.type != Editor.Type.GRAPHICS:
-			ep.Tabs.set_tab_title(current_tab,  %SyntaxLabel.text)
-			var code_edit_node = editor.get_node("%CodeEdit")
+	
+	if active_tab_editor_node is Editor and (active_tab_editor_node.type != Editor.Type.GRAPHICS):
+		if active_tab_editor_node.type != Editor.Type.GRAPHICS:
+			ep.Tabs.set_tab_title(ep.Tabs.get_current_tab(),  ep.editor_name_to_use(%SyntaxLabel.text))
+			var code_edit_node = active_tab_editor_node.get_node("%CodeEdit")
+			
 			if code_edit_node:
+				#print(text_without_tags)
 				code_edit_node.text = text_without_tags
-				return
+				ep.update_tabs_icon()
 			else:
 				print("Error: CodeEdit node not found in active Text tab.")
 		else: 
 			print("Error: Active tab is not a Text editor.")
-			
-	elif ep.Tabs.get_child(current_tab):
-		var editor = ep.Tabs.get_child(current_tab)
-		var FindCodeEdit = editor.get_child(0)
-		var code_edit_node = FindCodeEdit.get_node("%CodeEdit")
-		if code_edit_node:
-			code_edit_node.text = text_without_tags
-			return
+		
+	#elif ep.Tabs.get_child(current_tab_indx):
+		#var editor = ep.Tabs.get_child(current_tab_indx)
+		#var FindCodeEdit = editor.get_child(0)
+		#var code_edit_node = FindCodeEdit.get_node("%CodeEdit")
+		#if code_edit_node:
+			#code_edit_node.text = text_without_tags
+			#return
 	else:
 		print("Error: Active tab is not an Editor.")

--- a/src/Scripts/UI/Controls/EditorCodeEdit.gd
+++ b/src/Scripts/UI/Controls/EditorCodeEdit.gd
@@ -5,3 +5,7 @@ extends CodeEdit
 ## Everytime the editor content is saved, this should be updated.
 var saved_content: String
 
+
+
+func _on_text_changed() -> void:
+	SingletonObject.UpdateUnsavedTabIcon.emit()

--- a/src/Scripts/UI/Views/ChatPane.gd
+++ b/src/Scripts/UI/Views/ChatPane.gd
@@ -468,7 +468,7 @@ func update_token_estimation():
 
 	var token_count = provider.estimate_tokens_from_prompt(create_prompt(chi))
 
-	%EstimatedTokensLabel.text = "%s¢" % [(provider.token_cost * token_count) *1000]
+	%EstimatedTokensLabel.text = "%s¢" % [(provider.token_cost * token_count) *100]
 
 
 # region Edit provider Title

--- a/src/Scripts/UI/Views/EditorPane.gd
+++ b/src/Scripts/UI/Views/EditorPane.gd
@@ -117,7 +117,7 @@ func add(type: Editor.Type, file = null, name_ = null, associated_object = null)
 
 	# check if we're opening a file that's already open or for the same associated_object (except null)
 	# if so just switch to that editor
-	for editor: Editor in self.Tabs.get_children():
+	for editor: Editor in Tabs.get_children():
 		if not editor is Editor: 
 			continue
 		if editor.file == file or (associated_object != null and editor.associated_object == associated_object):
@@ -128,8 +128,8 @@ func add(type: Editor.Type, file = null, name_ = null, associated_object = null)
 	
 	editor_node.content_changed.connect(_on_editor_content_changed.bind(editor_node))
 	
-	self.Tabs.add_child(editor_node)
-	self.Tabs.current_tab = self.Tabs.get_tab_count()-1
+	Tabs.add_child(editor_node)
+	Tabs.current_tab = Tabs.get_tab_count()-1
 	
 	if name_: 
 		var tab_name = editor_name_to_use(name_)
@@ -178,12 +178,12 @@ func is_named_being_used(proposed_name: String) -> bool:
 func editor_name_to_use(proposed_name: String) -> String:
 	var collisions = 0
 	for i in range(Tabs.get_tab_count()):
-		if Tabs.get_tab_title(i).split(" ")[0] == proposed_name:
+		if Tabs.get_tab_title(i).split(" (")[0] == proposed_name:
 			collisions+=1
 	if collisions == 0:
 		return proposed_name
 	else:
-		return proposed_name + "(" + str(Tabs.get_tab_count() + 1) + ")"
+		return proposed_name + " (" + str(collisions) + ")"
 
 
 func unsaved_editors() -> Array[Editor]:

--- a/src/assets/themes/terminal.tres
+++ b/src/assets/themes/terminal.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Theme" load_steps=6 format=3 uid="uid://cdp8qvjvdfebe"]
 
-[ext_resource type="FontFile" uid="uid://bq0vtem6coath" path="res://addons/markdownlabel/assets/fonts/Fira_Code/static/FiraCode-Regular.ttf" id="1_a62c1"]
+[ext_resource type="FontFile" uid="uid://dba1103evgoyq" path="res://addons/markdownlabel/assets/fonts/Fira_Code/static/FiraCode-Regular.ttf" id="1_a62c1"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_lxph6"]
 bg_color = Color(0.0784314, 0.0784314, 0.0784314, 1)


### PR DESCRIPTION
fixed replace all not working when active editor tab is a graphics tab. Replace all now checks if the active tab is a graphics tab and creates a text tab if so